### PR TITLE
fix: Stop using deprecated set-output

### DIFF
--- a/.github/workflows/autobuildall.yml
+++ b/.github/workflows/autobuildall.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '42 7 * * *' # At 0742 each day
 
+permissions:  # added using https://github.com/step-security/secure-workflows
+  contents: read
+
 jobs:
   check_for_new_stable:
     runs-on: ubuntu-latest
@@ -12,7 +15,7 @@ jobs:
       dartversion: ${{ steps.dartversion.outputs.dartversion }}
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v3 # checkout the repository content to github runner.
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - id: dartversion
         name: Check stable version
@@ -21,11 +24,11 @@ jobs:
           curl -s $DDURL | jq -r .stable.version > DART_STABLE_VERSION
           if [ -z "$(git status --porcelain)" ]; then 
             echo 'No new stable release of Dart'
-            echo "::set-output name=dartversion::NOTNEW"
+            echo "dartversion=NOTNEW" >> $GITHUB_OUTPUT
             exit 0
           else
             DART_VERSION=$(cat DART_STABLE_VERSION)
-            echo "::set-output name=dartversion::$DART_VERSION"
+            echo "dartversion=${DART_VERSION}" >> $GITHUB_OUTPUT
           fi          
   
   build_multi_arch_images:
@@ -36,20 +39,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325 # v2.2.1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2.1.0 
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push buildimage
         id: docker_build1
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
         with:
           file: ./at-buildimage/Dockerfile
           build-args: DART_VERSION=${{ env.DART_VERSION }}
@@ -65,7 +68,7 @@ jobs:
 
       - name: Build and push dartshowplatform
         id: docker_build3
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
         with:
           file: ./dartshowplatform/Dockerfile
           build-args: DART_VERSION=${{ env.DART_VERSION }}
@@ -80,7 +83,7 @@ jobs:
             linux/arm/v7
 
       - name: Google Chat Notification
-        uses: Co-qn/google-chat-notification@releases/v1
+        uses: Co-qn/google-chat-notification@b9227d9daa4638c9782a5bd16c4abb86268127a1 # releases/v1
         with:
           name: New images build for Dart SDK ${{ env.DART_VERSION }}
           url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
@@ -93,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout_to_update_version
-        uses: actions/checkout@v3 # checkout the repository content to github runner.
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Update stable version
         id: dartversion
@@ -102,7 +105,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@331d02c7e2104af23ad5974d4d5cbc58a3e6dc77 # v4.2.2
         with:
           token: ${{ secrets.MY_GITHUB_TOKEN }}
           commit-message: 'chore: Bump DART_VERSION file to match latest Stable release'


### PR DESCRIPTION
`set-output` has been deprecated by GitHub, leading to warnings in Actions:

![image](https://user-images.githubusercontent.com/478926/203754608-3d4e5433-7470-46f1-a315-20238e822aee.png)

**- What I did**

* modified set-output lines to use `$GITHUB_OUTPUT` mechanism
* constrained token permissions
* pinned dependencies

**- How I did it**

[How to Patch the Deprecated set-output in GitHub Workflows and in Container Actions](https://dev.to/cicirello/how-to-patch-the-deprecated-set-output-in-github-workflows-and-in-container-actions-9co) provided guidance for the set-output changes needed.

[StepSecurity Secure Workflow](https://app.stepsecurity.io/secureworkflow) used to modify token permissions and pin dependencies.

**- How to verify it**

Deprecation warnings will stop once merged.

**- Description for the changelog**

fix: Stop using deprecated set-output