### PR TITLE
feat: Add more tags to combined image

### DIFF
--- a/.github/workflows/autobuildall.yml
+++ b/.github/workflows/autobuildall.yml
@@ -102,6 +102,7 @@ jobs:
           tags: |
             atsigncompany/buildimage:riscv
             atsigncompany/buildimage:riscv-GHA_${{ github.run_number }}
+            atsigncompany/buildimage:riscv-beta_${{ env.BETA_VERSION  }}
           platforms: |
             linux/riscv64
 
@@ -109,6 +110,13 @@ jobs:
         id: docker_manifest_build
         run: |
           docker buildx imagetools create -t atsigncompany/buildimage:automated \
+            --append atsigncompany/buildimage:riscv
+          docker buildx imagetools create -t atsigncompany/buildimage:${{ env.DART_VERSION }} \
+            --append atsigncompany/buildimage:riscv
+          docker buildx imagetools create \
+            -t atsigncompany/buildimage:${{ env.DART_VERSION }}-beta_${{ env.BETA_VERSION  }} \
+            --append atsigncompany/buildimage:riscv
+          docker buildx imagetools create -t atsigncompany/buildimage:GHA_${{ github.run_number }} \
             --append atsigncompany/buildimage:riscv
 
       - name: Build and push dartshowplatform


### PR DESCRIPTION
At present the only composite image tag is `:automated`, which is less descriptive than I'd like to see alongside a SHA for a pinned image

**- What I did**

Added additional tags to the Combine Build Images step

**- How I did it**

Using a selection of env variables to provide descriptive tags

**- How to verify it**

Run the workflow manually once merged.

**- Description for the changelog**

feat: Add more tags to combined image