### PR TITLE
fix: Composite tag need to be present from earlier stage

### DIFF
--- a/.github/workflows/autobuildall.yml
+++ b/.github/workflows/autobuildall.yml
@@ -66,6 +66,7 @@ jobs:
           tags: |
             atsigncompany/buildimage:automated
             atsigncompany/buildimage:${{ env.DART_VERSION }}
+            atsigncompany/buildimage:${{ env.DART_VERSION }}-beta_${{ env.BETA_VERSION  }}
             atsigncompany/buildimage:GHA_${{ github.run_number }}
           platforms: |
             linux/amd64


### PR DESCRIPTION
The later combine stage needs the tag to be present

**- What I did**

Added line to create composite tag

**- How to verify it**

Another manual run of the workflow

**- Description for the changelog**

fix: Composite tag need to be present from earlier stage