### PR TITLE
fix: Drop duplicate beta in label

### DIFF
--- a/.github/workflows/autobuildall.yml
+++ b/.github/workflows/autobuildall.yml
@@ -66,7 +66,7 @@ jobs:
           tags: |
             atsigncompany/buildimage:automated
             atsigncompany/buildimage:${{ env.DART_VERSION }}
-            atsigncompany/buildimage:${{ env.DART_VERSION }}-beta_${{ env.BETA_VERSION  }}
+            atsigncompany/buildimage:${{ env.DART_VERSION }}_${{ env.BETA_VERSION  }}
             atsigncompany/buildimage:GHA_${{ github.run_number }}
           platforms: |
             linux/amd64
@@ -103,7 +103,7 @@ jobs:
           tags: |
             atsigncompany/buildimage:riscv
             atsigncompany/buildimage:riscv-GHA_${{ github.run_number }}
-            atsigncompany/buildimage:riscv-beta_${{ env.BETA_VERSION  }}
+            atsigncompany/buildimage:riscv_${{ env.BETA_VERSION  }}
           platforms: |
             linux/riscv64
 
@@ -115,7 +115,7 @@ jobs:
           docker buildx imagetools create -t atsigncompany/buildimage:${{ env.DART_VERSION }} \
             --append atsigncompany/buildimage:riscv
           docker buildx imagetools create \
-            -t atsigncompany/buildimage:${{ env.DART_VERSION }}-beta_${{ env.BETA_VERSION  }} \
+            -t atsigncompany/buildimage:${{ env.DART_VERSION }}_${{ env.BETA_VERSION  }} \
             --append atsigncompany/buildimage:riscv
           docker buildx imagetools create -t atsigncompany/buildimage:GHA_${{ github.run_number }} \
             --append atsigncompany/buildimage:riscv


### PR DESCRIPTION
`beta` was appearing twice in the tag

**- What I did**

removed `beta`

**- How to verify it**

Has already been verified by a manual run against the branch

**- Description for the changelog**

fix: Drop duplicate beta in label