### PR TITLE
fix: Remove libatomic.so.1 as it's no longer in debian:unstable

### DIFF
--- a/at-buildimage/Dockerfile.RV64
+++ b/at-buildimage/Dockerfile.RV64
@@ -38,8 +38,7 @@ RUN set -eux; \
         riscv64) \
             TRIPLET="riscv64-linux-gnu" ; \
             FILES="/lib/ld-linux-riscv64-lp64d.so.1 \
-                /lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1 \
-                /usr/lib/riscv64-linux-gnu/libatomic.so.1" ;; \
+                /lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1" ;; \
         *) \
             echo "Unsupported architecture" ; \
             exit 5;; \


### PR DESCRIPTION
Builds have been failing with:

> `cannot stat '/usr/lib/riscv64-linux-gnu/libatomic.so.1': No such file or directory`

**- What I did**

Removed `libatomic.so.1` from the list of files to be copied.

**- How I did it**

Ran an interactive container with `debian:unstable` and confirmed that `libatomic.so.1` has been removed.

**- How to verify it**

Run the build with workflow_dispatch

**- Description for the changelog**

fix: Remove libatomic.so.1 as it's no longer in debian:unstable