### PR TITLE
fix: Install libatomic1 and copy library to runtime

### DIFF
--- a/at-buildimage/Dockerfile.RV64
+++ b/at-buildimage/Dockerfile.RV64
@@ -13,6 +13,7 @@ RUN set -eux; \
         curl \
         dnsutils \
         git \
+        libatomic1 \
         openssh-client \
         unzip \
     ; \
@@ -38,7 +39,8 @@ RUN set -eux; \
         riscv64) \
             TRIPLET="riscv64-linux-gnu" ; \
             FILES="/lib/ld-linux-riscv64-lp64d.so.1 \
-                /lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1" ;; \
+                /lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1 \
+                /usr/lib/riscv64-linux-gnu/libatomic.so.1" ;; \
         *) \
             echo "Unsupported architecture" ; \
             exit 5;; \


### PR DESCRIPTION
`libatomic.so.1` might have been dropped from the base image, but `dart compile exe` still needs it:

```
 > [linux/riscv64 build 4/4] RUN dart compile exe /app/showplatform.dart -o /app/dartshowplatform:
0.221 dart: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
------
./dartshowplatform/Dockerfile:4
--------------------
   2 |     WORKDIR /app
   3 |     COPY ./dartshowplatform/showplatform.dart .
   4 | >>> RUN dart compile exe /app/showplatform.dart -o /app/dartshowplatform
   5 |     
   6 |     FROM scratch
--------------------
ERROR: failed to solve: process "/bin/sh -c dart compile exe /app/showplatform.dart -o /app/dartshowplatform" did not complete successfully: exit code: 127
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c dart compile exe /app/showplatform.dart -o /app/dartshowplatform" did not complete successfully: exit code: 127
```

**- What I did**

Reinstated `libatomic.so.1` to `\runtime`

**- How I did it**

The Dockerfile.RV64 now adds `libatomic1` to the list of `apt-get install` 

**- How to verify it**

Run workflow_dispatch on the AutoBuildAll workflow

**- Description for the changelog**

fix: Install libatomic1 and copy library to runtime