### PR TITLE
feat: Align beta version with stable

### DIFF
--- a/.github/workflows/autobuildall.yml
+++ b/.github/workflows/autobuildall.yml
@@ -31,7 +31,7 @@ jobs:
             fi
           fi
           DART_VERSION=$(cat DART_STABLE_VERSION)
-          BETA_VERSION=$(curl -s $DDURL | jq -r .beta.version)
+          BETA_VERSION=$(echo $DART_VERSION | rev | cut -d"." -f2 - | rev)".0"
           echo "dartversion=${DART_VERSION}" >> $GITHUB_OUTPUT
           echo "betaversion=${BETA_VERSION}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
@XavierChanth has identified dependency issues with using betas that are a minor version ahead of stable

Meanwhile the Dart team are now releasing betas that align with the first release of each new stable minor version (but sadly not patches).

**- What I did**

Modified build script to set the beta version to align with stable

**- How to verify it**

Run the autobuildall workflow using workflow_dispatch

**- Description for the changelog**

feat: Align beta version with stable