### PR TITLE
fix: Stray space in cut gives wrong version

### DIFF
--- a/.github/workflows/autobuildall.yml
+++ b/.github/workflows/autobuildall.yml
@@ -31,7 +31,7 @@ jobs:
             fi
           fi
           DART_VERSION=$(cat DART_STABLE_VERSION)
-          BETA_VERSION=$(echo $DART_VERSION | rev | cut -d"." -f2 - | rev)".0"
+          BETA_VERSION=$(echo $DART_VERSION | rev | cut -d"." -f2- | rev)".0"
           echo "dartversion=${DART_VERSION}" >> $GITHUB_OUTPUT
           echo "betaversion=${BETA_VERSION}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The present cut statement doesn't extract the correct MAJOR.MINOR version

**- What I did**

Removed stray space

**- How to verify it**

Try another workflow_dispatch run of the build

**- Description for the changelog**

fix: Stray space in cut gives wrong version