### PR TITLE
fix: Add additional flags for compile

### DIFF
--- a/dartshowplatform/Dockerfile
+++ b/dartshowplatform/Dockerfile
@@ -1,7 +1,8 @@
 FROM atsigncompany/buildimage:automated AS build
 WORKDIR /app
 COPY ./dartshowplatform/showplatform.dart .
-RUN dart compile exe /app/showplatform.dart -o /app/dartshowplatform
+RUN dart compile exe --extra-gen-snapshot-options=--target_unknown_cpu \
+  /app/showplatform.dart -o /app/dartshowplatform
 
 FROM scratch
 COPY --from=build /runtime/ /


### PR DESCRIPTION
Suggestion from https://github.com/dart-lang/sdk/issues/54198#issuecomment-1834284744 to deal with armv7 build failing on docker buildx emulated armv7

**- What I did**

Added `--extra-gen-snapshot-options=--target_unknown_cpu` to `dart compile exe` line

**- How to verify it**

Manual run of build workflow

**- Description for the changelog**

fix: Add additional flags for compile