### PR TITLE
build(deps): Switch from Sid to Trixie

### DIFF
--- a/at-buildimage/Dockerfile.RV64
+++ b/at-buildimage/Dockerfile.RV64
@@ -1,4 +1,4 @@
-FROM debian:unstable-slim
+FROM debian:trixie-slim
 
 ARG BETA_VERSION="3.0.0-290.3.beta"
 ARG X64_SHA="eaaeee6be87a140a08ae0b6cc76e23ff4e5cb0ef7bbfa8ffa08b90e26b826e6e"


### PR DESCRIPTION
RISC-V support hasn't found its way to Debian 12 yet, which is the stable release that the official Dart Docker images use, but it is now available in the 'testing' release for Debian 13 "Trixie", which will become stable next year, and is a more stable release than 'unstable' "Sid"

**- What I did**

Updated Docker image tag to use `trixie-slim`

**- How to verify it**

When Docker 3.5.1 image is released an automated build will pick it up and build here.

**- Description for the changelog**

build(deps): Switch from Sid to Trixie