### PR TITLE
build(deps): Revert to unstable Debian for RISC-V build

### DIFF
--- a/at-buildimage/Dockerfile.RV64
+++ b/at-buildimage/Dockerfile.RV64
@@ -1,4 +1,4 @@
-FROM debian:trixie-slim
+FROM debian:unstable-slim
 
 ARG BETA_VERSION="3.0.0-290.3.beta"
 ARG X64_SHA="eaaeee6be87a140a08ae0b6cc76e23ff4e5cb0ef7bbfa8ffa08b90e26b826e6e"


### PR DESCRIPTION
Workaround for #196 

**- What I did**

Changed base image back to `unstable-slim` (aka `sid`)

**- How to verify it**

I'll rerun the failed build workflow for Dart 3.5.2

I've manually verified that the required packages install OK on `unstable-slim`

**- Description for the changelog**

build(deps): Revert to unstable Debian for RISC-V build