### PR TITLE
fix: ensure user/home is set in valgrind container

### DIFF
--- a/valgrind/Dockerfile
+++ b/valgrind/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:noble@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782
 
-RUN apt-get update; \
+RUN useradd -ms /bin/bash atsign; \
+  apt-get update; \
   apt-get upgrade -y; \
   apt-get install -y git-core \
   build-essential \
@@ -11,8 +12,10 @@ RUN apt-get update; \
   just \
   valgrind \
   gcc \
-  cmake
+  cmake;
 
+USER atsign
+ENV HOME=/home/atsign
 WORKDIR /mnt/workdir
 
 CMD [ "tail", "-f", "/dev/null" ]


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Ensure home is set in valgrind container.

**- How I did it**

- Create `atsign` user
- Set USER to atsign
- Set HOME to /home/atsign

**- How to verify it**

**- Description for the changelog**
fix: ensure user/home is set in valgrind container
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->