### PR TITLE
build(deps): Rule for Dependabot to ignore beta images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
       - "/valgrind/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*" # Applies to all Docker images
+        versions: ["*beta*"] # Ignore versions that include 'beta'
     groups:
       docker:
         patterns:


### PR DESCRIPTION
#270 attempted to update from a stable image to a beta :man_facepalming: 

**- What I did**

Added an ignore rule

**- How I did it**

Prompted Gemini with:

```text
how do I prevent dependabot from bumping to docker images that have beta or rc in their name?
```

Which produced:

```yaml
version: 2
updates:
  - package-ecosystem: "docker"
    directory: "/"
    schedule:
      interval: "daily"
    ignore:
      - dependency-name: "*" # Applies to all Docker images
        versions: ["*beta*", "*rc*"] # Ignore versions that include 'beta' or 'rc'
```

**- How to verify it**

No more PRs for betas

**- Description for the changelog**

build(deps): Rule for Dependabot to ignore beta images