### PR TITLE
fix: Revert broken ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,6 @@ updates:
       - "/valgrind/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "*" # Applies to all Docker images
-        versions: ["*beta*"] # Ignore versions that include 'beta'
     groups:
       docker:
         patterns:


### PR DESCRIPTION
#271 didn't work:

```text
The property '#/updates/1/ignore/0/versions' includes invalid version requirements for a docker ignore condition
```

**- What I did**

Reverted #271

**- How to verify it**

Check Insights > Dependency Graph > Dependabot

**- Description for the changelog**

fix: Revert broken ignore rule