### PR TITLE
ci: Add Docker image signing

### DIFF
--- a/.github/workflows/autobuildall.yml
+++ b/.github/workflows/autobuildall.yml
@@ -29,18 +29,38 @@ jobs:
     env:
       DART_VERSION: ${{ needs.get_stable_version.outputs.dartversion }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for creating OIDC tokens for signing.
     steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
+
       - name: Login to DockerHub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Metadata (tags, labels) for buildimage
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        with:
+          tags: |
+            type=raw,value=automated
+            type=raw,value=${{ env.DART_VERSION }}
+            type=raw,value=GHA_${{ github.run_number }}
+          images: |
+            atsigncompany/buildimage
+          labels: |
+            org.opencontainers.image.description=Dart Build Image
 
       - name: Build and push Multi Arch buildimage
         id: docker_build
@@ -49,15 +69,36 @@ jobs:
           file: ./at-buildimage/Dockerfile
           push: true
           provenance: false
-          tags: |
-            atsigncompany/buildimage:automated
-            atsigncompany/buildimage:${{ env.DART_VERSION }}
-            atsigncompany/buildimage:GHA_${{ github.run_number }}
+          tags: ${{ steps.meta.outputs.tags }}
           platforms: |
             linux/amd64
             linux/arm64/v8
             linux/arm/v7
             linux/riscv64
+
+      - name: Sign buildimage images with GitHub OIDC Token
+        env:
+          DIGEST: ${{ steps.docker_build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
+
+      - name: Metadata (tags, labels) for dartshowplatform
+        id: meta_sp
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        with:
+          tags: |
+            type=raw,value=automated
+            type=raw,value=${{ env.DART_VERSION }}
+            type=raw,value=GHA_${{ github.run_number }}
+          images: |
+            atsigncompany/dartshowplatform
+          labels: |
+            org.opencontainers.image.description=Dart Show Platform application
 
       - name: Build and push dartshowplatform
         id: docker_build_sp
@@ -66,15 +107,23 @@ jobs:
           file: ./dartshowplatform/Dockerfile
           push: true
           provenance: false
-          tags: |
-            atsigncompany/dartshowplatform:automated
-            atsigncompany/dartshowplatform:${{ env.DART_VERSION }}
-            atsigncompany/dartshowplatform:GHA_${{ github.run_number }}
+          tags: ${{ steps.meta_sp.outputs.tags }}
           platforms: |
             linux/amd64
             linux/arm64/v8
             linux/arm/v7
             linux/riscv64
+
+      - name: Sign showplatform images with GitHub OIDC Token
+        env:
+          DIGEST: ${{ steps.docker_build_sp.outputs.digest }}
+          TAGS: ${{ steps.meta_sp.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
 
       - name: Google Chat Notification
         uses: Co-qn/google-chat-notification@3691ccf4763537d6e544bc6cdcccc1965799d056 # releases/v1

--- a/.github/workflows/autobuildall.yml
+++ b/.github/workflows/autobuildall.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-
       - name: Login to DockerHub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -11,7 +11,13 @@ permissions: # added using https://github.com/step-security/secure-workflows
 jobs:
   build_images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for creating OIDC tokens for signing.
     steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
@@ -24,16 +30,38 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
+        with:
+          tags: |
+            type=raw,value=latest
+            type=raw,value=GHA_${{ github.run_number }}
+          images: |
+            atsigncompany/valgrind
+          labels: |
+            org.opencontainers.image.description=Valgrind Image
+
       - name: Build and push Multi Arch images
+        id: docker_build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           file: ./valgrind/Dockerfile
           push: true
           provenance: false
-          tags: |
-            atsigncompany/valgrind:latest
-            atsigncompany/valgrind:GHA_${{ github.run_number }}
+          tags: ${{ steps.meta.outputs.tags }}
           platforms: |
             linux/amd64
             linux/arm64/v8
             linux/arm/v7
+
+      - name: Sign the images with GitHub OIDC Token
+        env:
+          DIGEST: ${{ steps.docker_build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}

--- a/README.md
+++ b/README.md
@@ -101,3 +101,15 @@ to build and push the valgrind image for amd64, arm & arm64 platforms.
 ## License
 
 The contents of this repository are licensed using the [Apache 2.0 License](LICENSE)
+
+## Docker image signing
+
+This repo is the source for a number of Docker images, and they're signed
+during the build process so that you can verify their authenticity using
+[cosign](https://github.com/sigstore/cosign):
+
+```sh
+cosign verify atsigncompany/buildimage:automated \
+--certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+--certificate-identity-regexp='^https://github.com/atsign-company/at_dockerfiles/.+'
+```


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/304

**- What I did**

Added image signing

**- How I did it**

Based on https://github.com/atsign-foundation/at_server/pull/2411

**- How to verify it**

Wait until images have been rebuilt (weekly for valgrind, on new Dart release for buildimage) then follow verification instructions.

**- Description for the changelog**

ci: Add Docker image signing