### PR TITLE
feat: Add Caddy image with DigitalOcean DNS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     directories:
       - "/at-buildimage/"
       - "/valgrind/"
+      - "/caddy-do-dns/"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/caddy.yml
+++ b/.github/workflows/caddy.yml
@@ -1,0 +1,68 @@
+name: Caddy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'caddy-do-dns/Dockerfile'
+
+permissions: # added using https://github.com/step-security/secure-workflows
+  contents: read
+
+jobs:
+  build_images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for creating OIDC tokens for signing.
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
+        with:
+          tags: |
+            type=raw,value=latest
+            type=raw,value=GHA_${{ github.run_number }}
+          images: |
+            atsigncompany/caddy-do-dns
+          labels: |
+            org.opencontainers.image.description=Caddy with DigitalOcean DNS
+
+      - name: Build and push Multi Arch images
+        id: docker_build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          file: ./caddy-do-dns/Dockerfile
+          push: true
+          provenance: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: |
+            linux/amd64
+
+      - name: Sign the images with GitHub OIDC Token
+        env:
+          DIGEST: ${{ steps.docker_build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -2,8 +2,11 @@ name: Valgrind
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "42 6 * * 0" # At 0642 every Sunday
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'valgrind/Dockerfile'
 
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/README.md
+++ b/README.md
@@ -87,9 +87,19 @@ docker run --rm --platform linux/amd64 -ti \
 Available on Dockerhub as
 [atsigncompany/valgrind](https://hub.docker.com/r/atsigncompany/valgrind)
 
+## caddy-do-dns
+
+The [Caddy](https://caddyserver.com/) reverse proxy with
+[DigitalOcean DNS](https://github.com/caddy-dns/digitalocean) so that we can
+get certificates using ACME services like LetsEncrypt with a DNS validation
+rather than opening up port 80 for HTTP.
+
+Available on Dockerhub as
+[atsigncompany/caddy-do-dns](https://hub.docker.com/r/atsigncompany/caddy-do-dns)
+
 ## Automation
 
-There are two GitHub Actions workflows:
+There are three GitHub Actions workflows:
 
 1. [autobuildall.yml](.github/workflows/autobuildall.yml) uses docker_build
 to build and push at-buildimage and dartshowplatform for amd64, arm, arm64 &
@@ -97,6 +107,10 @@ riscv64 platforms.
 
 2. [valgrind.yml](.github/workflows/valgrind.yml) uses docker_build
 to build and push the valgrind image for amd64, arm & arm64 platforms.
+
+3. [caddy.yml](.github/workflows/caddy.yml) uses docker_build
+to build and push the caddy-do-dns image for amd64.
+
 
 ## License
 

--- a/caddy-do-dns/Dockerfile
+++ b/caddy-do-dns/Dockerfile
@@ -1,0 +1,10 @@
+# Based on https://github.com/caddy-dns/digitalocean
+# but with SHA pinning rather than version ARG
+
+
+FROM caddy:builder@sha256:6e3ed727ce8695fc58e0a8de8e5d11888f6463c430ea5b40e0b5f679ab734868 AS builder
+RUN caddy-builder \
+    github.com/caddy-dns/digitalocean
+
+FROM caddy:alpine@sha256:953131cfea8e12bfe1c631a36308e9660e4389f0c3dfb3be957044d3ac92d446
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy


### PR DESCRIPTION
We need a Caddy image that can generate certs using DigitalOcean DNS.

**- What I did**

* Modified Dockerfile from https://github.com/caddy-dns/digitalocean by pinning SHAs
  * Dependabot will update SHAs when new versions are available
  * and the workflow will run when those changes are merged
* Valgrind image also now updates for new SHAs being merged rather than cron

**- How I did it**

Rework of existing Dockerfiles and workflows

**- How to verify it**

I'll do an initial workflow_dispatch run once this is merged

**- Description for the changelog**

feat: Add Caddy image with DigitalOcean DNS