### PR TITLE
build(deps): Add 7 day cooldown for all package ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -16,6 +18,8 @@ updates:
       - "/caddy-do-dns/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       docker:
         patterns:


### PR DESCRIPTION
Progresses https://github.com/atsign-foundation/operations/issues/389

**- What I did**

Added cooldown block to each dependency

**- How I did it**

Copied from atsign-foundation

**- How to verify it**

:eyes: on future Dependabot bumps

**- Description for the changelog**

build(deps): Add 7 day cooldown for all package ecosystems
